### PR TITLE
Add simple Discord bot with basic commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-Cool readme
+# Simple Discord Bot
+
+This repository contains a minimal Discord bot demonstrating five basic commands.
+
+## Commands
+- `!ping` – Responds with "Pong!" to check if the bot is running.
+- `!greet` – Greets the user who invoked the command.
+- `!roll [sides]` – Rolls a die with the given number of sides (defaults to six).
+- `!flip` – Flips a coin and returns heads or tails.
+- `!echo <message>` – Echoes back the provided message.
+
+## Running the bot
+1. Install dependencies: `pip install discord.py`
+2. Set your Discord bot token in the `DISCORD_TOKEN` environment variable.
+3. Start the bot with `python bot.py`.
+
+This example is intentionally simple and meant for educational purposes.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,41 @@
+import os
+import random
+from discord.ext import commands
+
+# Read the bot token from an environment variable for security
+TOKEN = os.getenv("DISCORD_TOKEN")
+
+# Configure the bot with a simple prefix
+bot = commands.Bot(command_prefix="!")
+
+@bot.command(help="Responds with pong")
+async def ping(ctx):
+    """Simple ping command to check responsiveness."""
+    await ctx.send("Pong!")
+
+@bot.command(help="Greet the user")
+async def greet(ctx):
+    """Greets the user who invoked the command."""
+    await ctx.send(f"Hello {ctx.author.display_name}!")
+
+@bot.command(help="Roll a die with an optional number of sides")
+async def roll(ctx, sides: int = 6):
+    """Roll a dice. Defaults to six sides if not specified."""
+    result = random.randint(1, sides)
+    await ctx.send(f"🎲 You rolled a {result}")
+
+@bot.command(help="Flip a coin")
+async def flip(ctx):
+    """Flip a coin and return heads or tails."""
+    outcome = random.choice(["Heads", "Tails"])
+    await ctx.send(outcome)
+
+@bot.command(help="Echo the provided message")
+async def echo(ctx, *, message: str):
+    """Echo back the user's message."""
+    await ctx.send(message)
+
+if __name__ == "__main__":
+    if not TOKEN:
+        raise ValueError("DISCORD_TOKEN environment variable not set.")
+    bot.run(TOKEN)


### PR DESCRIPTION
## Summary
- create simple Discord bot with five basic commands: ping, greet, roll, flip, and echo
- document commands and setup instructions in README

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6897a9afbb708320b71658703d6d9882