### PR TITLE
Refactor bot into cogs and add message relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # Simple Discord Bot
 
-This repository contains a minimal Discord bot demonstrating five basic commands.
+This repository contains a minimal Discord bot demonstrating five basic commands and a message relay listener implemented using cogs.
 
 ## Commands
+The following commands reside in `cogs/FunCog.py`:
 - `!ping` – Responds with "Pong!" to check if the bot is running.
 - `!greet` – Greets the user who invoked the command.
 - `!roll [sides]` – Rolls a die with the given number of sides (defaults to six).
 - `!flip` – Flips a coin and returns heads or tails.
 - `!echo <message>` – Echoes back the provided message.
+
+## Message Relay
+`cogs/RelayCog.py` listens for all incoming messages and forwards them to the channel with ID `964663566366027826` in the guild with ID `842956728085118997`.
 
 ## Running the bot
 1. Install dependencies: `pip install discord.py`

--- a/bot.py
+++ b/bot.py
@@ -1,41 +1,21 @@
 import os
-import random
+import discord
 from discord.ext import commands
 
 # Read the bot token from an environment variable for security
 TOKEN = os.getenv("DISCORD_TOKEN")
 
+# Configure intents to allow message content access
+intents = discord.Intents.default()
+intents.message_content = True
+
 # Configure the bot with a simple prefix
-bot = commands.Bot(command_prefix="!")
-
-@bot.command(help="Responds with pong")
-async def ping(ctx):
-    """Simple ping command to check responsiveness."""
-    await ctx.send("Pong!")
-
-@bot.command(help="Greet the user")
-async def greet(ctx):
-    """Greets the user who invoked the command."""
-    await ctx.send(f"Hello {ctx.author.display_name}!")
-
-@bot.command(help="Roll a die with an optional number of sides")
-async def roll(ctx, sides: int = 6):
-    """Roll a dice. Defaults to six sides if not specified."""
-    result = random.randint(1, sides)
-    await ctx.send(f"🎲 You rolled a {result}")
-
-@bot.command(help="Flip a coin")
-async def flip(ctx):
-    """Flip a coin and return heads or tails."""
-    outcome = random.choice(["Heads", "Tails"])
-    await ctx.send(outcome)
-
-@bot.command(help="Echo the provided message")
-async def echo(ctx, *, message: str):
-    """Echo back the user's message."""
-    await ctx.send(message)
+bot = commands.Bot(command_prefix="!", intents=intents)
 
 if __name__ == "__main__":
     if not TOKEN:
         raise ValueError("DISCORD_TOKEN environment variable not set.")
+    # Load cogs containing commands and listeners
+    bot.load_extension("cogs.FunCog")
+    bot.load_extension("cogs.RelayCog")
     bot.run(TOKEN)

--- a/cogs/FunCog.py
+++ b/cogs/FunCog.py
@@ -1,0 +1,40 @@
+import random
+from discord.ext import commands
+
+
+class FunCog(commands.Cog):
+    """Fun commands for the bot."""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(help="Responds with pong")
+    async def ping(self, ctx):
+        """Simple ping command to check responsiveness."""
+        await ctx.send("Pong!")
+
+    @commands.command(help="Greet the user")
+    async def greet(self, ctx):
+        """Greets the user who invoked the command."""
+        await ctx.send(f"Hello {ctx.author.display_name}!")
+
+    @commands.command(help="Roll a die with an optional number of sides")
+    async def roll(self, ctx, sides: int = 6):
+        """Roll a dice. Defaults to six sides if not specified."""
+        result = random.randint(1, sides)
+        await ctx.send(f"🎲 You rolled a {result}")
+
+    @commands.command(help="Flip a coin")
+    async def flip(self, ctx):
+        """Flip a coin and return heads or tails."""
+        outcome = random.choice(["Heads", "Tails"])
+        await ctx.send(outcome)
+
+    @commands.command(help="Echo the provided message")
+    async def echo(self, ctx, *, message: str):
+        """Echo back the user's message."""
+        await ctx.send(message)
+
+
+def setup(bot):
+    bot.add_cog(FunCog(bot))

--- a/cogs/RelayCog.py
+++ b/cogs/RelayCog.py
@@ -1,0 +1,34 @@
+from discord.ext import commands
+
+
+class RelayCog(commands.Cog):
+    """Relays all messages to a specific channel."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.guild_id = 842956728085118997
+        self.channel_id = 964663566366027826
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        # Ignore messages from bots to prevent loops
+        if message.author.bot:
+            return
+
+        # Avoid relaying messages that are already in the target channel
+        if message.guild and message.guild.id == self.guild_id and message.channel.id == self.channel_id:
+            await self.bot.process_commands(message)
+            return
+
+        guild = self.bot.get_guild(self.guild_id)
+        if guild:
+            channel = guild.get_channel(self.channel_id)
+            if channel:
+                await channel.send(f"{message.author}: {message.content}")
+
+        # Ensure commands still work
+        await self.bot.process_commands(message)
+
+
+def setup(bot):
+    bot.add_cog(RelayCog(bot))


### PR DESCRIPTION
## Summary
- Move existing bot commands into `cogs/FunCog.py`
- Add `RelayCog` to forward all messages to a designated guild/channel
- Update main bot to load new cogs and enable message content intents

## Testing
- `python -m py_compile bot.py cogs/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6897ad1c90488320bfd86403b3d03e05